### PR TITLE
Add stats endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,6 +141,22 @@ app.all('/container/:containerId', function (req, res) {
 });
 
 /**
+ * List all of the containers
+ */
+app.get('/containers', function (req, res) {
+    docker.listContainers({ all: true }, function (err, containers) {
+        if (err) {
+            res.status(500);
+            res.send(err);
+            return;
+        }
+        res.status(200);
+        res.send(containers);
+    });
+});
+
+
+/**
  * Restart the container by the ID specified
  */
 app.get('/container/:containerId/restart', function (req, res) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-dockermon",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A RESTful HTTP endpoint which can return the status of Docker containers for Home Automation controllers like Home Assistant",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-dockermon",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A RESTful HTTP endpoint which can return the status of Docker containers for Home Automation controllers like Home Assistant",
   "main": "index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -134,6 +134,16 @@ The response will be a json object with a `result` key containing the output fro
 
 *Warning:* There is no confirmation for the command to be executed. Going to the URL in your browser will start the container.
 
+### GET /container/{container name}/stats
+
+Allows you to read various statistics of a running Docker container, including CPU usage and memory usage.
+
+The response will be a json object with various keys including `precpu_stats` `cpu_stats` and `memory_stats`. The information returned may vary on the version of Docker your host machine is running.
+
+*Heads Up:* There's a known issue where some host systems (like Synology NAS) may not return a response when calling this endpoint.
+
+Thanks to [@thelittlefireman](https://github.com/thelittlefireman) for contributing this endpoint.
+
 ### GET /container/{container name}/stop
 
 Allows you to send a simple HTTP request to stop a Docker container.

--- a/readme.md
+++ b/readme.md
@@ -124,7 +124,77 @@ curl --request POST \
 --data '{"command": "ls -a"}'
 ```
 
+### GET /container/{container name}/start
+
+Allows you to send a simple HTTP request to start a Docker container.
+
 The response will be a json object with a `result` key containing the output from the command executed.
+
+*Warning:* There is no confirmation for the command to be executed. Going to the URL in your browser will start the container.
+
+### GET /container/{container name}/stop
+
+Allows you to send a simple HTTP request to stop a Docker container.
+
+The response will be a json object with a `result` key containing the output from the command executed.
+
+*Warning:* There is no confirmation for the command to be executed. Going to the URL in your browser will stop the container.
+
+### GET /containers
+
+Outputs a list of all stopped and started containers on the host.
+
+This is the same as performing a `docker ps -a` command on the host machine.
+
+The response will be a json object, with each container in its own key. An example response is below.
+
+```json
+[{
+	"Id": "2096eaf1a58f1730234d2e30c982021c196192eae9f41c6abf8fa26aad348477",
+	"Names": ["/hadockermon"],
+	"Image": "hadockermon",
+	"ImageID": "sha256:e7352295ec274a441f691a8c83f8823137654f5d4df5fb187d9f1cee1f4711d6",
+	"Command": "/bin/sh -c 'npm start'",
+	"Created": 1523522864,
+	"Ports": [{
+		"IP": "0.0.0.0",
+		"PrivatePort": 8126,
+		"PublicPort": 8126,
+		"Type": "tcp"
+	}],
+	"Labels": {},
+	"State": "running",
+	"Status": "Up 19 seconds",
+	"HostConfig": {
+		"NetworkMode": "default"
+	},
+	"NetworkSettings": {
+		"Networks": {
+			"bridge": {
+				"IPAMConfig": null,
+				"Links": null,
+				"Aliases": null,
+				"NetworkID": "ed342d9b95ab77f57172ca3fdd2dc87682ee7e0c3f94db7bb3a83ba81a5f2135",
+				"EndpointID": "bfdec2f98a2521093e1210c1cc5135e3a788be5b80b8409d8652915a5ee38224",
+				"Gateway": "172.17.0.1",
+				"IPAddress": "172.17.0.2",
+				"IPPrefixLen": 16,
+				"IPv6Gateway": "",
+				"GlobalIPv6Address": "",
+				"GlobalIPv6PrefixLen": 0,
+				"MacAddress": "02:42:ac:11:00:02"
+			}
+		}
+	},
+	"Mounts": [{
+		"Source": "/var/run/docker.sock",
+		"Destination": "/var/run/docker.sock",
+		"Mode": "",
+		"RW": true,
+		"Propagation": "rprivate"
+	}]
+}]
+```
 
 ### Home Assistant RESTful Switch
 


### PR DESCRIPTION
Adds the `stats` endpoint against containers. Thanks to @thelittlefireman

There's a known issue with some systems not returning any response when calling this endpoint.