### PR TITLE
added endpoint for docker pull

### DIFF
--- a/index.js
+++ b/index.js
@@ -429,6 +429,42 @@ app.post('/container/:containerId/exec', function(req, res) {
     });
 })
 
+
+/**
+ * Pull the lastest image for the given repository, with or without tag
+ */
+app.get('/pull/:repoTag', function (req, res) {
+    var repoTag = req.params.repoTag;
+    console.log("Pull" + repoTag);
+    docker.pull(repoTag, function (err, stream) {
+        if (err) {
+            if (config.get("debug")) {
+              console.log("Failed to pull docker image " + repoTag);
+              console.log(err);
+            }
+
+            res.status(500);
+            res.send(err);
+            return;
+        }
+        console.log("Pulling image...");
+        const chunks = [];
+        stream.on("data", function (chunk) {
+            chunks.push(chunk.toString());
+        });
+
+        // Send the buffer or you can put it into a var
+        stream.on("end", function () {
+            // We remove the first 8 chars as the contain a unicode START OF HEADING followed by ENQUIRY.
+            res.send({
+                status: true,
+                jresult: chunks.join('').substr(8)
+            });
+        });
+    });
+});
+
+
 //Attempt to connect to the Docker daemon
 switch (config.get("docker_connection:type")) {
     case "http":

--- a/index.js
+++ b/index.js
@@ -433,8 +433,8 @@ app.post('/container/:containerId/exec', function(req, res) {
 /**
  * Pull the lastest image for the given repository, with or without tag
  */
-app.get('/pull/:repoTag', function (req, res) {
-    var repoTag = req.params.repoTag;
+app.get('/pull/*', function (req, res) {
+    var repoTag = req.params[0];
     console.log("Pull" + repoTag);
     docker.pull(repoTag, function (err, stream) {
         if (err) {


### PR DESCRIPTION
I was checking out this project and #20 and thought I'd take a quick stab at this. Ultimately, I'd like to be able to implement a home assistant script, triggerable from the front-end, that does the equivalent of a pull, rm, and run to update home assistant. I think the next step would be to implement an endpoint that does the removing and subsequent running. I just followed the [dockerode docs example](https://www.npmjs.com/package/dockerode#equivalent-of-docker-pull-in-dockerode-) but don't have any prior experience with the library.