### PR TITLE
Add snyk files for Travis builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN mkdir -p /usr/src/app && mkdir /config
 WORKDIR /usr/src/app
 
 COPY package.json /usr/src/app
+COPY .snyk /usr/src/app
 RUN npm install
 
 COPY default_settings.json /usr/src/app

--- a/Dockerfile.RaspberryPi
+++ b/Dockerfile.RaspberryPi
@@ -5,6 +5,7 @@ RUN mkdir -p /usr/src/app && mkdir /config
 WORKDIR /usr/src/app
 
 COPY package.json /usr/src/app
+COPY .snyk /usr/src/app
 RUN npm install
 
 COPY default_settings.json /usr/src/app


### PR DESCRIPTION
Make sure we add the snyk files to the Docker images so that our build
process doesn't break.