### PR TITLE
Fix for convict validation issues

### DIFF
--- a/config/configuration.yaml.sample
+++ b/config/configuration.yaml.sample
@@ -1,10 +1,6 @@
 debug: false
 http:
   port: 8126
-  username: 
-  password:
 docker_connection:
   type: socket
   path: /var/run/docker.sock
-  host:
-  port:

--- a/default_settings.js
+++ b/default_settings.js
@@ -1,5 +1,6 @@
 var convict = require('convict');
     yaml = require('js-yaml');
+    fs = require('fs');
 
 var config = convict({
   debug: {
@@ -16,12 +17,12 @@ var config = convict({
       username: {
           doc: 'Optional. The HTTP Username for authentication',
           format: String,
-          default: ''
+          default: undefined
       }, 
       password: {
         doc: 'Optional. The HTTP Password for authentication',
         format: String,
-        default: '',
+        default: undefined,
         sensitive: true
     }
   },
@@ -37,13 +38,14 @@ var config = convict({
       default: '/var/run/docker.sock'
     },
     host: {
-      doc: 'URL to remote docker host',
+      doc: 'Optional. URL to remote docker host',
       format: String,
-      default: ''
+      default: undefined
     },
     port: {
-      doc: 'Port on remote docker host',
-      format: 'port_or_windows_named_pipe'
+      doc: 'Optional. Port on remote docker host',
+      format: 'port_or_windows_named_pipe',
+      default: undefined
     }
   }
 });
@@ -52,7 +54,15 @@ var config = convict({
 convict.addParser({ extension: ['yml', 'yaml'], parse: yaml.safeLoad });
 var config_dir = process.env.config_dir || "./config";
 console.log("Loading settings from " + config_dir);
-config.loadFile(config_dir + '/configuration.yaml');
+
+//Check if the configuration file exists, if it doesn't then skip this
+try{
+  if (fs.existsSync(config_dir + '/configuration.yaml')) {
+    config.loadFile(config_dir + '/configuration.yaml');
+  }
+} catch(err) {
+  console.warn("No configuration file detected. Using default settings");
+}
 
 // Perform validation
 config.validate({allowed: 'warn'});

--- a/readme.md
+++ b/readme.md
@@ -30,8 +30,8 @@ You can change some configuration options for this service by editing config/con
 | http.password          | If set all calls to this service must use HTTP basic authentication with this password. **If set, must not be an empty value.**                         | None                 |
 | docker_connection.type | How the service connects to docker. Valid options are socket or http                                             | socket               |
 | docker_connection.path | The path to the Docker socket. Useful when running this service on the host directly (not in a Docker container) | /var/run/docker.sock |
-| docker_connection.host | The host IP/Domain of the host Docker to connect to. Only used when `docker_connection.type` is set to `http`. If `docker_connection.type` is set to `http` do not add this to your configuration YAML.         | None                 |
-| docker_connection.port | The port of the host Docker to connect to. Only used when `docker_connection.type` is set to `http`.  If `docker_connection.type` is set to `http` do not add this to your configuration YAML.                  | None                 |
+| docker_connection.host | The host IP/Domain of the host Docker to connect to. Only used when `docker_connection.type` is set to `http`. **If set, must not be an empty value.**         | None                 |
+| docker_connection.port | The port of the host Docker to connect to. Only used when `docker_connection.type` is set to `http`.  **If set, must not be an empty value.**                  | None                 |
 
 ### Connecting to Docker
 

--- a/readme.md
+++ b/readme.md
@@ -25,13 +25,13 @@ You can change some configuration options for this service by editing config/con
 | Option                 | Description                                                                                                      | Default Value        |
 |------------------------|------------------------------------------------------------------------------------------------------------------|----------------------|
 | debug                  | If set to true, will output some helpful debug messages to the console.                                          | false                |
-| http.port              | The HTTP port the service listens on.                                                                            | 8126                 |
-| http.username          | If set all calls to this service must use HTTP basic authentication with this username.                          | None                 |
-| http.password          | If set all calls to this service must use HTTP basic authentication with this password.                          | None                 |
+| http.port              | The HTTP port the service listens on. Must be a valid HTTP port or windows socket.                                                                          | 8126                 |
+| http.username          | If set all calls to this service must use HTTP basic authentication with this username. **If set, must not be an empty value.**                         | None                 |
+| http.password          | If set all calls to this service must use HTTP basic authentication with this password. **If set, must not be an empty value.**                         | None                 |
 | docker_connection.type | How the service connects to docker. Valid options are socket or http                                             | socket               |
 | docker_connection.path | The path to the Docker socket. Useful when running this service on the host directly (not in a Docker container) | /var/run/docker.sock |
-| docker_connection.host | The host IP/Domain of the host Docker to connect to. Only used when docker_connection.type is set to http        | None                 |
-| docker_connection.port | The port of the host Docker to connect to. Only used when docker_connection.type is set to http                  | None                 |
+| docker_connection.host | The host IP/Domain of the host Docker to connect to. Only used when `docker_connection.type` is set to `http`. If `docker_connection.type` is set to `http` do not add this to your configuration YAML.         | None                 |
+| docker_connection.port | The port of the host Docker to connect to. Only used when `docker_connection.type` is set to `http`.  If `docker_connection.type` is set to `http` do not add this to your configuration YAML.                  | None                 |
 
 ### Connecting to Docker
 


### PR DESCRIPTION
Fixes #46

Allows ha-dockermon to be started without a configuration file being
set.

Updates the sample configuration file to remove blank entries for ports
and username/passwords. These values can no longer be left blank in the
YAML files as they will cause validation errors.

Updates the readme to make note of these new requirements