### PR TITLE
Add MQTT capability

### DIFF
--- a/config/configuration.yaml.sample
+++ b/config/configuration.yaml.sample
@@ -4,3 +4,13 @@ http:
 docker_connection:
   type: socket
   path: /var/run/docker.sock
+mqtt:
+  enabled: true
+  host: 127.0.0.1
+  base_topic: ha_dockermon/my_server
+  whitelist_containers:
+    - mysql
+    - home-assistant
+    - influx-grafana
+  hass_discovery:
+    enabled: true

--- a/default_settings.js
+++ b/default_settings.js
@@ -47,6 +47,56 @@ var config = convict({
       format: 'port_or_windows_named_pipe',
       default: undefined
     }
+  },
+  mqtt: {
+    enabled: {
+      doc: 'Whether MQTT should be enabled or not',
+      format: Boolean,
+      default: false
+    },
+    host: {
+      doc: 'MQTT server host',
+      format: String,
+      default: '127.0.0.1'
+    },
+    port: {
+      doc: 'Optional. Port for MQTT server',
+      format: 'port_or_windows_named_pipe',
+      default: undefined
+    },
+    username: {
+      doc: 'Optional. The HTTP Username for authentication',
+      format: String,
+      default: undefined
+    }, 
+    password: {
+      doc: 'Optional. The HTTP Password for authentication',
+      format: String,
+      default: undefined,
+      sensitive: true
+    },
+    base_topic: {
+      doc: 'MQTT base topic to send updates. Should be unique per HA-Dockermon instance, ie ha_dockermon/hostname',
+      format: String,
+      default: 'ha_dockermon'
+    },
+    scan_interval: {
+      doc: 'Number of seconds HA-Dockermon will scan the docker host for updates',
+      format: 'int',
+      default: 30
+    },
+    hass_discovery: {
+      enabled: {
+        doc: 'Whether HA-Dockermon should send Home Assistant Discovery entities',
+        format: Boolean,
+        default: true
+      },
+      base_topic: {
+        doc: 'The base topic Home Assistant listens for new devices',
+        format: String,
+        default: 'homeassistant'
+      }
+    }
   }
 });
 

--- a/default_settings.js
+++ b/default_settings.js
@@ -85,6 +85,11 @@ var config = convict({
       format: 'int',
       default: 30
     },
+    whitelist_containers: {
+      doc: 'If set, only container names in this list will be published via MQTT discovery',
+      format: Array,
+      default: undefined
+    },
     hass_discovery: {
       enabled: {
         doc: 'Whether HA-Dockermon should send Home Assistant Discovery entities',

--- a/index.js
+++ b/index.js
@@ -36,7 +36,9 @@ if (config.get("mqtt.enabled")) {
         dockermonMqtt.startMqtt();
     });
 } else {
+    if (config.get("debug")) {
     console.log("MQTT not enabled");
+}
 }
 
 //Setup express
@@ -646,15 +648,22 @@ function postCallbackRequest(url, data)
 
 process.on('SIGINT', function() {
     console.log("Caught interrupt signal");
-    if (intervalObj)
+    if (config.get('mqtt.enabled')) {
+        if (intervalObj != undefined)
         clearInterval(intervalObj);
     mqtt_client.end(function(){
         process.exit();
     }); 
+    } else {
+        process.exit();
+    }
 });
 process.on('SIGTERM', function() {
     console.log("Caught terminate signal");
-    if (intervalObj)
+    if (config.get('mqtt.enabled')) {
+        if (intervalObj != undefined)
         clearInterval(intervalObj);
+    }
+    
     process.exit();
 });

--- a/index.js
+++ b/index.js
@@ -37,8 +37,8 @@ if (config.get("mqtt.enabled")) {
     });
 } else {
     if (config.get("debug")) {
-    console.log("MQTT not enabled");
-}
+        console.log("MQTT not enabled");
+    }
 }
 
 //Setup express
@@ -649,11 +649,11 @@ function postCallbackRequest(url, data)
 process.on('SIGINT', function() {
     console.log("Caught interrupt signal");
     if (config.get('mqtt.enabled')) {
-        if (intervalObj != undefined)
-        clearInterval(intervalObj);
-    mqtt_client.end(function(){
-        process.exit();
-    }); 
+        if (typeof intervalObj != 'undefined')
+            clearInterval(intervalObj);
+        mqtt_client.end(function(){
+            process.exit();
+        });
     } else {
         process.exit();
     }
@@ -661,8 +661,8 @@ process.on('SIGINT', function() {
 process.on('SIGTERM', function() {
     console.log("Caught terminate signal");
     if (config.get('mqtt.enabled')) {
-        if (intervalObj != undefined)
-        clearInterval(intervalObj);
+        if (typeof intervalObj != 'undefined')
+            clearInterval(intervalObj);
     }
     
     process.exit();

--- a/mqtt/hadockermon_mqtt.js
+++ b/mqtt/hadockermon_mqtt.js
@@ -1,0 +1,277 @@
+module.exports = {
+    config: null,
+    mqtt_client: null,
+    docker: null,
+
+    init: function(config, mqtt_client, docker)
+    {
+        this.config = config;
+        this.mqtt_client = mqtt_client;
+        this.docker = docker;
+    },
+
+    checkDeletedContainers: function(pushedContainers)
+    {
+        for (i in this.mqttContainers) {
+            if (pushedContainers.indexOf(i) < 0) {
+                //Was not pushed? Increment errors
+                this.mqttContainers[i].errors++;
+
+                //If we have three strikes, you're out!
+                if (mqttContainers[i].errors === 3) {
+                    this.mqttRemove(i);
+                }
+            } else {
+                this.mqttContainers[i].errors = 0;
+            }
+        }
+    },
+
+    handleMessage: function(topic, message, packet){
+        //Extract the topic we were sent on
+        var container_name = topic.replace(hadockermon.config.get("mqtt.base_topic") + "/", "").replace("/set", "");
+    
+        //Switch based on the type of message
+        if (message == "stop" || (hadockermon.config.get("mqtt.hass_discovery.enabled") && message == "off")) {
+            if (hadockermon.config.get("debug")) {
+                console.log("Stopping container " + container_name);
+            }
+            
+            getContainer(container_name, function (container) {
+                docker.getContainer(container.Id).stop(function (err, data) {
+                    if (err) {
+                        return;
+                    }
+                    setTimeout(function(){
+                        hadockermon.publishMqtt(mqtt_client);
+                    }, 2000);
+                });
+            }, function (status, message) {
+                console.log("Something went wrong? " + status + " " + message);
+                res.status(status);
+                if (message) {
+                    res.send(message);
+                }
+            })
+        } else if (message == "start" || (this.config.get("mqtt.hass_discovery.enabled") && message == "on")) {
+            getContainer(container_name, function (container) {
+                docker.getContainer(container.Id).start(function (err, data) {
+                    if (err) {
+                        return;
+                    }
+                    setTimeout(function(){
+                        hadockermon.publishMqtt(mqtt_client);
+                    }, 2000);
+                });
+            }, function (status, message) {
+                console.log("Something went wrong? " + status + " " + message);
+                res.status(status);
+                if (message) {
+                    res.send(message);
+                }
+            })
+        }
+        
+    },
+
+    initializeEntities: function (name, containerInfo)
+    {
+        if (this.config.get("debug")) {
+            console.log("Setting up entity via HASS discovery for " + name);
+        }
+
+        //Publish to the Home Assistant topic with a switch
+        var jsonConfig = {
+            name: name,
+            state_topic: this.config.get("mqtt.base_topic") + "/" + name + "/state",
+            command_topic: this.config.get("mqtt.base_topic") + "/" + name + "/set",
+            availability_topic: this.config.get("mqtt.base_topic") + "/status",
+            payload_on: "on",
+            payload_off: "off",
+            payload_available: "online",
+            payload_not_available: "offline",
+            unique_id: this.config.get("mqtt.base_topic").replace("/","_") + name.replace("-", "_"),
+            json_attributes_topic: this.config.get("mqtt.base_topic") + "/" + name + "/attributes"
+        }
+
+        this.mqtt_client.publish(this.config.get("mqtt.hass_discovery.base_topic") + "/switch/" + this.config.get("mqtt.base_topic").replace("/", "_") + "/" + name.replace("-", "_") + "/config", JSON.stringify(jsonConfig), {
+            retain: true
+        });
+    },
+
+    hassDiscoveryPublish: function(name, containerInfo)
+    {
+        if (this.config.get("debug")) {
+            console.log("Sending discovery state message for " + name);
+        }
+        var state = "off";
+        var containerState = containerInfo.SynoStatus || containerInfo.State;
+        if (containerState == "running") {
+            state = "on";
+        }
+        this.mqtt_client.publish(this.config.get("mqtt.base_topic") + "/" + name + "/state", state , {
+            retain: true
+        });
+
+        //Now publish some attributes
+
+        //Container name, status, image name, running since
+        var jsonAttributes = {
+            name: name,
+            icon: "mdi:docker",
+            status: containerInfo.Status,
+            state:  containerState
+        }
+        if (containerInfo.Image) {
+            jsonAttributes.image = containerInfo.Image;
+        }
+
+        //Customise the icon based on the image
+        if (jsonAttributes.image) {
+            if (jsonAttributes.image.indexOf("homeassistant") > -1) {
+                jsonAttributes.icon = "mdi:home-assistant";
+            } else if (jsonAttributes.image.indexOf("zigbee2mqtt") > -1) {
+                jsonAttributes.icon = "mdi:zigbee";
+            } else if (jsonAttributes.image.indexOf("plex") > -1 || jsonAttributes.image.indexOf("tautulli") > -1) {
+                jsonAttributes.icon = "mdi:plex";
+            } else if (jsonAttributes.image.indexOf("zwave") > -1 || jsonAttributes.image.indexOf("z-wave") > -1) {
+                jsonAttributes.icon = "mdi:z-wave";
+            } else if (jsonAttributes.image.indexOf("mysql") > -1 || jsonAttributes.image.indexOf("mariadb") > -1  || jsonAttributes.image.indexOf("influx") > -1) {
+                jsonAttributes.icon = "mdi:database";
+            } else if (jsonAttributes.image.indexOf("transmission") > -1 || jsonAttributes.image.indexOf("nzbget") > -1) {
+                jsonAttributes.icon = "mdi:download-multiple";
+            } else if (jsonAttributes.image.indexOf("radarr") > -1 || jsonAttributes.image.indexOf("sonarr") > -1) {
+                jsonAttributes.icon = "mdi:radar";
+            } else if (jsonAttributes.image.indexOf("vpn") > -1) {
+                jsonAttributes.icon = "mdi:vpn";
+            } else if (jsonAttributes.image.indexOf("traccar") > -1) {
+                jsonAttributes.icon = "mdi:crosshairs-gps";
+            } else if (jsonAttributes.image.indexOf("alexa") > -1) {
+                jsonAttributes.icon = "mdi:amazon-alexa";
+            } else if (jsonAttributes.image.indexOf("homekit") > -1 || jsonAttributes.image.indexOf("homebridge") > -1) {
+                jsonAttributes.icon = "mdi:apple";
+            } else if (jsonAttributes.image.indexOf("nodered") > -1 || jsonAttributes.image.indexOf("node-red") > -1) {
+                jsonAttributes.icon = "mdi:nodejs";
+            }
+
+        }
+
+        this.mqtt_client.publish(this.config.get("mqtt.base_topic") + "/" + name + "/attributes", JSON.stringify(jsonAttributes), {
+            retain: false
+        });
+    },
+
+    mqttRemove: function(name)
+    {
+        //Publish a remove topic
+        if (this.config.get("mqtt.hass_discovery.enabled")) {
+            this.mqtt_client.publish(this.config.get("mqtt.hass_discovery.base_topic") + "/switch/" + this.config.get("mqtt.base_topic").replace("/","_") + name.replace("-", "_") + "/config", "", {
+                retain: false
+            });
+        } else {
+            //Just publish the state as destroyed
+            this.mqtt_client.publish(this.config.get("mqtt.base_topic") + "/" + name + "/state", "destroyed", {
+                retain: false
+            });
+        }
+    },
+
+    publishMqtt: function()
+    {
+        //Store the containers we published to in an array for tracking later
+        this.pushedContainers = [];
+
+        //Get all containers
+        hadockermon = this;
+        this.docker.listContainers( {
+            all: true
+        }, function (err, containers) {
+            containers.forEach(function (containerInfo, idx, all_containers) {
+                //Use the first name index as the name for this container
+                var name = hadockermon.topicName(containerInfo.Names);
+
+                //Are we already tracking this container?
+                if (!hadockermon.mqttContainers[name]) {
+                    //No, subscribe to this topic!
+                    hadockermon.subscribe(name);
+                    if (hadockermon.config.get("mqtt.hass_discovery.enabled")) {
+                        hadockermon.initializeEntities(name, containerInfo);
+                    }
+                }
+
+                if (hadockermon.config.get("mqtt.hass_discovery.enabled")) {
+                    hadockermon.hassDiscoveryPublish(name, containerInfo);
+                } else {
+                    //Just publish the state
+                    hadockermon.mqtt_client.publish(hadockermon.config.get("mqtt.base_topic") + "/" + name + "/state", containerInfo.State , {
+                        retain: false
+                    });
+                }
+
+                hadockermon.pushedContainers.push(name);
+
+                //If this is the last item, we need to check for any deleted items
+                if (idx === all_containers.length - 1){ 
+                    hadockermon.checkDeletedContainers(hadockermon.pushedContainers);
+                }
+            });
+        });
+    },
+
+    startMqtt: function() {    
+        var loop_interval = this.config.get("mqtt.scan_interval");
+    
+        //Store an array of containers we have tracked
+        //If we can't detect this container, we'll assume it has been deleted
+        //and remove the entity from Home Assistant if applicable
+    
+        this.mqttContainers = {};
+    
+        this.publishMqtt();
+
+        hadockermon = this;
+
+        this.mqtt_client.on('message', hadockermon.handleMessage)
+    
+        this.mqttPublisher = setInterval(function(){
+            hadockermon.publishMqtt(mqtt_client);
+        }, loop_interval * 1000);
+
+        var topic = this.config.get("mqtt.base_topic") + "/status";
+        this.mqtt_client.publish(topic, "online", {
+            retain: true
+        });
+    
+        this.mqtt_client.on('disconnect', function(){
+            console.log("MQTT disconnected");
+            clearInterval(this.mqttPublisher);
+        });
+    
+        // process.exit();
+    },
+
+    subscribe: function(name)
+    {
+        this.mqttContainers[name] = {
+            errors: 0
+        }
+
+        if (this.config.get("debug")) {
+            console.log("Subscribing to " + this.config.get("mqtt.base_topic") + "/" + name + "/set");
+        }
+
+        this.mqtt_client.subscribe(this.config.get("mqtt.base_topic") + "/" + name + "/set");
+    },
+
+    topicName: function(names)
+    {
+        if (names[0]) {
+            name = names[0];
+            if (name[0] == "/") {
+                name = name.substr(1);
+            }
+        }
+        
+        return name;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "express": "^4.16.2",
     "express-basic-auth": "^1.2.0",
     "js-yaml": "^3.13.1",
+    "mqtt": "^3.0.0",
     "snyk": "^1.200.1"
   },
   "snyk": true

--- a/readme.md
+++ b/readme.md
@@ -8,14 +8,16 @@ HA Dockermon
 
 This is a simple Node service which checks the status of a Docker Container and returns a RESTful response. It can also be used to issue `start` `stop` `pause` `unpause` and `restart` commands. The primary purpose of this service is to interface with [Home Assistant](https://home-assistant.io) on a [Synology NAS](http://amzn.to/2FAC28A).
 
-## Supported Features
-As of this release, you can:
+This service can optionally be used to expose Docker containers over an MQTT broker, and supports [Home Assistant's MQTT Discovery](https://www.home-assistant.io/docs/mqtt/discovery/) feature.
+
+## Supported Docker Features
 
 * Get the status of a container (running, stopped, paused).
 * Start, stop, pause, or unpause a container by issuing a `POST` request.
 * Start, stop, pause, or unpause a container by issuing a `GET` requst.
 * Restart a container by making a `GET` request to a URL for the container (details below).
 * Execute commands inside a container using the `/exec` endpoint of a container.
+* Pull a docker image for the latest version from the remote repository
 
 ## Getting Started
 
@@ -278,6 +280,8 @@ HA-Dockermon can also be used in combination with [Home Assistant's MQTT Discove
 
 HA-Dockermon will automatically create switches on your Home Assistant instance when a new container is started. HA-Dockermon will also automatically remove those entities when a container is destroyed on the host system.
 
+**Warning:** When exposing Home Assistant via MQTT discovery, a switch entity will exist for your Home Assistant instance. Any calls to services such as `switch.turn_off` that specify an entity_id of `all` **will** turn off all of your Docker containers, including Home Assistant and HA-Dockermon (if exposed).
+
 ### Base Topic
 When using MQTT, you should take care to set a unique base topic name for the configuration `mqtt.base_topic`. When adding entities to Home Assistant, HA-Dockermon will use the `mqtt.base_topic` to determine a unique ID for the container. This is important for container names which may be shared on multiple Docker hosts.
 
@@ -306,6 +310,25 @@ HA-Dockermon will add information about the container to the switch attributes. 
 * State (amount of time in state, status codes)
 * Status (running, exited, stopped)
 * Image and tag name (if available)
+
+### Use Without MQTT Disovery
+When the `mqtt.hass_discovery.enabled` setting is turned off, it is still possible to control docker containers via MQTT. You will need to manually send the correct events to HA-Dockermon to control those containers.
+
+Below is a sample switch for Home Assistant that can use MQTT without MQTT discovery.
+
+```yaml
+switch:
+  - platform: mqtt
+    name: "Home Assistant"
+    state_topic: "ha_dockermon/server/home_assistant/state"
+    command_topic: "ha_dockermon/server/home_assistant/set"
+    payload_on: "on"
+    payload_off: "off"
+    state_on: "on"
+    state_off: "off"
+    qos: 0
+    retain: true
+```
 
 
 # Further Reading

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,7 @@ You can change some configuration options for this service by editing config/con
 | mqtt.password                 | Optional. MQTT password to connect to the MQTT broker                                                                                                  |                      |
 | mqtt.base_topic               | MQTT base topic to send updates. Should be unique per HA-Dockermon instance, ie ha_dockermon/hostname                                                  | ha_dockermon         |
 | mqtt.scan_interval            | Number of seconds HA-Dockermon will scan the docker host for updates                                                                                   | 30                   |
+| mqtt.whitelist_containers            | If set, only container names in this list will be published via MQTT discovery                                                                                  |                    |
 | mqtt.hass_discovery.enabled   | Whether HA-Dockermon should send Home Assistant Discovery entities                                                                                     | true                 |
 | mqtt.hass_disovery.base_topic | The base topic Home Assistant listens for new devices                                                                                                  | homeassistant        |
 
@@ -293,6 +294,11 @@ In Home Assistant, these will be created as `switch.home_assistant` and `switch.
 
 ### Changing Base Topic
 Changing the `mqtt.base_topic` setting will cause duplicate entities to be created in Home Assistant. For this reason it is suggested that once you have set your `mqtt.base_topic` setting, you don't change it in the future.
+
+### Whitelisting Containers
+If you frequently create one-time containers to execute scripts, these may create un-necessary entities in your Home Assistant entity registry. 
+
+To avoid this, you can set HA-Dockermon to only expose the container names that you specify in the `mqtt.whitelist_containers` setting. Any container which does not have a name in this list will not be exposed by HA-Dockermon to Home Assistant, or be controllable via MQTT command topics.
 
 ### Switch Attributes
 HA-Dockermon will add information about the container to the switch attributes. Currently the information made available includes:


### PR DESCRIPTION
Adds the ability for containers to support Home Assistant's MQTT
discovery feature.

When enabled HA-Dockermon will create switch entities in Home Assistant
and report their states. Containers can also be stopped and started from
MQTT.

This is applicable for #48 