### PR TITLE
Send environment variables in GET response

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -53,6 +53,7 @@ RUN apt-get update \
 RUN curl -sL https://deb.nodesource.com/setup_10.x -o nodesource_setup.sh
 RUN bash nodesource_setup.sh
 RUN apt-get install -y nodejs
+RUN apt-get install -y vim
 
 # Setting the ENTRYPOINT to docker-init.sh will configure non-root access to 
 # the Docker socket if "overrideCommand": false is set in devcontainer.json. 

--- a/index.js
+++ b/index.js
@@ -193,11 +193,32 @@ app.all('/container/:containerId', function (req, res) {
                 console.log("Response received");
                 console.log(container);
             }
-            res.send({
+
+            var response = {
                 state: container.SynoStatus || container.State,
                 status: container.Status,
                 image: container.Image
+            };
+
+            docker.getContainer(container.Id).inspect(function(err, data){
+                //Put environment into the response
+                if (data.Config.Env) {
+                    var env = data.Config.Env;
+                    response.environment = {};
+                    for(i in env) {
+                        //Explode the =
+                        var exploded = env[i].split("=");
+                        var key = exploded[0];
+                        delete exploded[0];
+                        var value = exploded.join("=");
+                        response.environment[key] = value.substring(1);
+                    }
+                }
+
+                res.send(response);
+                console.log(data);
             });
+            
         }, function(status, message){
             res.status(status);
             if (config.get("debug"))


### PR DESCRIPTION
When making a call to a containers GET endpoint, we will now return an
array of Environment variables that apply to a docker container

Fixes #78